### PR TITLE
Use optimized proxes from TFOCS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -218,3 +218,8 @@ TSWLatexianTemp*
 
 # expex forward references with \gathertags
 *-tags.tex
+
+#JMF 16 Nov 2018
+saved_mats/
+profile_*
+*.mat

--- a/SSC_viaADMM.m
+++ b/SSC_viaADMM.m
@@ -286,6 +286,11 @@ function Afun = returnProxH( X, lambda, rho, affine )
      rChol   = chol( eye(p) + 1/rho*lambda*(XXt) );
      iYYt    = @(RHS) rChol\( rChol'\RHS);
      Afun    = @(RHS) RHS/rho - (lambda/(rho^2))*(X'*(iYYt(X*RHS)) );
+
+     %JMF 17 Nov 2018: if this is like ADMM for NNLS, then we can get a faster
+     %     step by using the SVD of X.  But since X in their timing experiments
+     %     is extremely underdetermined, the cost of the fw/bw subs should be tiny.
+     %     Yup, I profiled this and iYYt is 0.5 secs vs 18.9 secs for Afun.
  end
 end
 

--- a/SSC_viaADMM.m
+++ b/SSC_viaADMM.m
@@ -122,11 +122,12 @@ Afun    = returnProxH( X, lambda, rho, affine );
 parameters.usedFastShrinkage = false;
 softThresh  = @(X, t) sign(X).*max( 0, abs(X) - t );
 if 2==exist('tfocs_where','file')
-    if 3~=exist('shrink_mex','file')
+    if 3~=exist('shrink_mex2','file')
         addpath( fullfile( tfocs_where, 'mexFiles' ) );
     end
-    if 3==exist('shrink_mex','file')
-        softThresh  = @(x,t) shrink_mex(x,t); 
+    if 3==exist('shrink_mex2','file')
+        %softThresh  = @(x,t) shrink_mex(x,t); 
+        softThresh  = @(x,t) shrink_mex2(x,t); 
         parameters.usedFastShrinkage = true;
     else
         warning('SSC:mexNotCompiled',...

--- a/SSC_viaProxGradient.m
+++ b/SSC_viaProxGradient.m
@@ -77,12 +77,15 @@ end
 
 min_C  lambda_tfocs*||C||_1 + 1/2||X-XC||_F^2
 
-so lambda_tfocs = 1/lambda, and need to scale output objectgive function
+so lambda_tfocs = 1/lambda, and need to scale output objective function
 
 %}
 zeroID  = true; b = 1; nCols = n; lambda_tfocs = 1/lambda;
 if affine
-    prox    = prox_l1_and_sum( lambda_tfocs, b, nCols, zeroID, true );
+    %prox    = prox_l1_and_sum( lambda_tfocs, b, nCols, zeroID, true );
+    
+    %JMF 17 Nov 2018: use optimized version of prox_l1_and_sum
+    prox    = prox_l1_and_sum_optimized( lambda_tfocs, b, nCols, zeroID);
 else
     %prox    = prox_l1_mat( lambda_tfocs, nCols, zeroID ); % no sum(x)=b constraint.
     

--- a/SSC_viaProxGradient.m
+++ b/SSC_viaProxGradient.m
@@ -84,7 +84,10 @@ zeroID  = true; b = 1; nCols = n; lambda_tfocs = 1/lambda;
 if affine
     prox    = prox_l1_and_sum( lambda_tfocs, b, nCols, zeroID, true );
 else
-    prox    = prox_l1_mat( lambda_tfocs, nCols, zeroID ); % no sum(x)=b constraint.
+    %prox    = prox_l1_mat( lambda_tfocs, nCols, zeroID ); % no sum(x)=b constraint.
+    
+    %JMF 17 Nov 2018: use optimized version of prox_l1_mat
+    prox    = prox_l1_mat_optimized( lambda_tfocs, nCols, zeroID ); % no sum(x)=b constraint.
 end
 
 tfocs_opts.maxIts       = maxIter;

--- a/jmf_tests.m
+++ b/jmf_tests.m
@@ -27,7 +27,8 @@ function [] = profile_run()
     affine = true
     lambdaE = 1; % bogus parameter
 
-    shrink_mex2(struct('num_threads', 4));
+    shrink_mex2(struct('num_threads', 8));
+    prox_l1_and_sum_worker_mex(struct('num_threads', 8));
 
     profile clear;
     profile on;
@@ -63,15 +64,20 @@ function [] = run_time_scaling()
     K = 10;      % number of subspaces 
     d = 3;       % dimension of each subspace 
     sigma = 0.1; % noise standard deviation
-    %affine = true % What we really want
-    affine = false % less interesting, but easier prox to start speeding up
+    affine = true % What we really want
+    %affine = false % less interesting, but easier prox to start speeding up
     rho_all = 200:50:500; % the rho used in the paper
     rho_all = round(linspace(20,50,5)); % bogus rho for quicker testing
     alpha   = [30,90];
     maxIter = 30;
     numExp  = 5; % number of trials to run
     
-    shrink_mex2(struct('num_threads', 4));
+    shrink_mex2(struct('num_threads', 4)); % for linear and affine constraints, 8 threads doesn't help (doesn't hurt much either)
+                                           % this prox is memory bound?
+    prox_l1_and_sum_worker_mex(struct('num_threads', 8)); % cranking up the threads of this guy does help
+                                                          % use no more that 8 threads (on my 16 core workstation)
+                                                          % so that we stay fair to ADMM & other matlab stuff (e.g. matmat)
+                                                          % which uses 8 threads.
 
     ADMM_times = zeros(numel(rho_all), numExp);
     TFOCS_times = zeros(numel(rho_all), numExp);

--- a/jmf_tests.m
+++ b/jmf_tests.m
@@ -1,0 +1,213 @@
+function [] = jmf_tests(in1, in2)
+    
+    %profile_run();
+    %return
+    
+    if nargin >= 1
+        plot_time_scaling_driver(in1, in2);
+        return
+    end
+    run_time_scaling();
+
+end
+
+function [] = profile_run()
+    profile off;
+    clear all; % profile clear doesn't clear all the way or something... this seems to do it though.
+    
+    n   = 600;
+    p   = 256;
+    maxIter = 30;
+
+    X   = randn(p,n);
+    affine = true;
+    lambdaE = 1; % bogus parameter
+
+    profile clear;
+    profile on;
+    
+    % ADMM
+    % ---
+    %alpha_rho = 10;
+    %SSC_viaADMM(X, ...
+    %    'lambda', lambdaE, 'maxIter', maxIter, 'printEvery', 1,...
+    %    'tol', 1e-12, 'affine', affine, 'alpha_rho', alpha_rho, 'adaptiveRho', false,...
+    %    'errHistEvery', maxIter+100, 'residHistEvery', maxIter+100);
+    
+    % TFOCS
+    % ---
+    tfocs_opts = struct( 'errFcn', @(objective,C) errFcn(reshape(C,n,n)) );
+    tfocs_opts = struct();
+    SSC_viaProxGradient(X, 'lambda', lambdaE,...
+        'affine', affine, 'tfocs_opts', tfocs_opts , 'tol', 1e-6, 'maxIter', maxIter, ...
+        'printEvery', 1);
+    
+    profile off
+
+
+end
+
+function [] = run_time_scaling()
+    % Parameters for Section 4.2 of AAAI submission
+    % (comes from Stephen's paper_deom_3_cont.m)
+    % ---
+    p = 256;     % ambient dimension 
+    K = 10;      % number of subspaces 
+    d = 3;       % dimension of each subspace 
+    sigma = 0.1; % noise standard deviation
+    rho_all = 200:50:500; % the rho used in the paper
+    rho_all = round(linspace(20,50,5)); % bogus rho for quicker testing
+    alpha   = [30,90];
+    maxIter = 30;
+    numExp  = 1; % number of trials to run
+
+    ADMM_affine_times = zeros(numel(rho_all), numExp);
+    TFOCS_affine_times = zeros(numel(rho_all), numExp);
+
+    for densVal = 1 : numel(rho_all)
+        rho = rho_all(densVal);
+        N   = rho * K * d
+        
+        for trial = 1 : numExp
+            TmpBasis = randn(p, p);
+            [TmpBasis, ~] = qr(TmpBasis, 0);
+            X = zeros(p,N);
+            true_labels = zeros(N,1);
+            for i = 1 : K % for each subspace 
+                Ni = rho *d;
+                ind = randperm(p,d);
+                U  = TmpBasis(:,ind);
+                X(:, (i-1)*Ni+1:i*Ni) = U * randn(d, Ni) + sigma*randn(p,Ni);
+                true_labels((i-1)*Ni+1:i*Ni) = i; 
+            end
+            
+            % Set up solver params
+            % ---
+            affine = true; % with affine constraint
+            threshold = 1e-6;
+            lambdaE = 1; % TODO JMF 16 Nov 2018: this is a bogus parameter; okay for timing though?
+            
+            % ADMM
+            alpha_rho = 10; % TODO JMF 16 Nov 2018: this is a bogus parameter; okay for timing though?
+
+            t_ = tic();
+            SSC_viaADMM(X, ...
+                'lambda', lambdaE, 'maxIter', maxIter, 'printEvery', 1,...
+                'tol', 1e-12, 'affine', affine, 'alpha_rho', alpha_rho, 'adaptiveRho', false,...
+                'errHistEvery', maxIter+100, 'residHistEvery', maxIter+100);
+            
+            ADMM_affine_times(densVal,trial) = toc(t_);
+
+            % TFOCS
+            %tfocs_opts = struct( 'errFcn', @(objective,C) errFcn(reshape(C,n,n)) );
+            tfocs_opts = struct();
+            
+            t_ = tic();
+            
+            SSC_viaProxGradient(X, 'lambda', lambdaE,...
+                'affine', affine, 'tfocs_opts', tfocs_opts , 'tol', threshold, 'maxIter', maxIter, ...
+                'printEvery', 1);
+
+            TFOCS_affine_times(densVal,trial) = toc(t_);
+
+        end
+    end
+
+    save('time_scaling_data.mat');
+
+end
+
+function [] = plot_time_scaling_driver(in1, in2)
+    if nargin == 1
+        data_file = string(in1)
+        plot_time_scaling_single(data_file);
+
+    elseif nargin == 2
+        data_file_baseline = string(in1);
+        data_file_new = string(in2);
+        plot_time_scaling_compare(data_file_baseline, data_file_new);
+
+    else
+        error('unhandled number of input arguments');
+    end
+
+end
+
+function [] = plot_time_scaling_single(data_file)
+    load(data_file);
+
+    ADMM_affine_times_mean = mean(ADMM_affine_times, 2);
+    TFOCS_affine_times_mean = mean(TFOCS_affine_times, 2);
+
+    %TODO JMF 16 Nov 2018: plot std
+
+    % Plot runtime scaling on log-log
+    % ---
+    N_vec = rho_all * K * d;
+
+    figure(1);
+    clf;
+    hold on;
+
+    plot(N_vec, ADMM_affine_times_mean, 'LineWidth', 2);
+    plot(N_vec, TFOCS_affine_times_mean, 'LineWidth', 2);
+
+    hold off;
+    
+    set(gca, 'xscale', 'log');
+    set(gca, 'yscale', 'log');
+    xlim([N_vec(1) N_vec(end)]);
+
+    xlabel('number of data points');
+    ylabel('running time (sec.)');
+
+    legend('ADMM', 'TFOCS', 'Location', 'NorthWest');
+
+end
+
+function [] = plot_time_scaling_compare(data_file_baseline, data_file_new)
+    S_baseline = load(data_file_baseline);
+    S_new = load(data_file_new);
+
+    % Some sanity checks
+    % ---
+    if ~all(S_baseline.rho_all == S_new.rho_all)
+        error('rho_all vector doesn''t match in both files');
+    end
+
+
+    ADMM_affine_times_mean_baseline = mean(S_baseline.ADMM_affine_times, 2);
+    TFOCS_affine_times_mean_baseline = mean(S_baseline.TFOCS_affine_times, 2);
+    
+    ADMM_affine_times_mean_new = mean(S_new.ADMM_affine_times, 2);
+    TFOCS_affine_times_mean_new = mean(S_new.TFOCS_affine_times, 2);
+    
+    %TODO JMF 16 Nov 2018: plot std
+
+    % Plot runtime scaling on log-log
+    % ---
+    N_vec = S_baseline.rho_all * S_baseline.K * S_baseline.d;
+
+    figure(1);
+    clf;
+    hold on;
+
+    plot(N_vec, ADMM_affine_times_mean_baseline, '-', 'LineWidth', 2);
+    plot(N_vec, TFOCS_affine_times_mean_baseline, '-', 'LineWidth', 2);
+
+    plot(N_vec, ADMM_affine_times_mean_new, '--', 'LineWidth', 2);
+    plot(N_vec, TFOCS_affine_times_mean_new, '--', 'LineWidth', 2);
+
+    hold off;
+    
+    set(gca, 'xscale', 'log');
+    set(gca, 'yscale', 'log');
+    xlim([N_vec(1) N_vec(end)]);
+
+    xlabel('number of data points');
+    ylabel('running time (sec.)');
+
+    legend('ADMM (baseline)', 'TFOCS (baseline)', 'ADMM (new)', 'TFOCS (new)', 'Location', 'NorthWest');
+
+end
+

--- a/jmf_tests.m
+++ b/jmf_tests.m
@@ -19,13 +19,15 @@ function [] = profile_run()
     profile off;
     clear all; % profile clear doesn't clear all the way or something... this seems to do it though.
     
-    n   = 6000;
+    n   = 600;
     p   = 256;
     maxIter = 30;
 
     X   = randn(p,n);
-    affine = false
+    affine = true
     lambdaE = 1; % bogus parameter
+
+    shrink_mex2(struct('num_threads', 4));
 
     profile clear;
     profile on;
@@ -68,6 +70,8 @@ function [] = run_time_scaling()
     alpha   = [30,90];
     maxIter = 30;
     numExp  = 5; % number of trials to run
+    
+    shrink_mex2(struct('num_threads', 4));
 
     ADMM_times = zeros(numel(rho_all), numExp);
     TFOCS_times = zeros(numel(rho_all), numExp);

--- a/set_paths.m
+++ b/set_paths.m
@@ -1,0 +1,2 @@
+addpath('~/projects/TFOCS-fork');
+addpath('~/projects/TFOCS-fork/mexFiles');


### PR DESCRIPTION
I've written some mex functions in TFOCS to speed up the runtime of `prox_l1_mat` and `prox_l1_and_sum`.  The new proxes are in `prox_l1_mat_optimized` and `prox_l1_and_sum_optimized`.

Included in this PR are the changes to `SSC_viaADMM.m` and `SSC_viaProxGradient.m`, as well as my test driver.

`prox_l1_mat_optimized` uses `shrink_mex2`, which allows you to change the number of threads it uses.  You can do that with

```
shrink_mex2(struct('num_threads', 4));
```

`prox_l1_and_sum_optimized` uses `prox_l1_and_sum_worker_mex`, which allows you to change the number of threads in the same manner:

```
prox_l1_and_sum_worker_mex(struct('num_threads', 8));
```

To get the best runtime out of TFOCS and ADMM, you'll need to experiment with the number of threads used.  I've found that 4 threads for `shrink_mex2` is best on my desktop, since the operation isn't FLOP dominant.  `prox_l1_and_sum_worker_mex` should use as many threads as you can, but keep in mind that MATLAB only uses 8 threads if you have 16 logical cores (8 physical).  So using more than 8 would be unfair.

