### PR TITLE
TFOCS PR renames optimized prox_l1_mat/prox_l1_and_sum

### DIFF
--- a/SSC_viaProxGradient.m
+++ b/SSC_viaProxGradient.m
@@ -82,15 +82,11 @@ so lambda_tfocs = 1/lambda, and need to scale output objective function
 %}
 zeroID  = true; b = 1; nCols = n; lambda_tfocs = 1/lambda;
 if affine
-    %prox    = prox_l1_and_sum( lambda_tfocs, b, nCols, zeroID, true );
-    
-    %JMF 17 Nov 2018: use optimized version of prox_l1_and_sum
-    prox    = prox_l1_and_sum_optimized( lambda_tfocs, b, nCols, zeroID);
+    %JMF 2 Dec 2018: optimized version is now the default in TFOCS; will use mex if it's compiled
+    prox    = prox_l1_and_sum(lambda_tfocs, b, nCols, zeroID);
 else
-    %prox    = prox_l1_mat( lambda_tfocs, nCols, zeroID ); % no sum(x)=b constraint.
-    
-    %JMF 17 Nov 2018: use optimized version of prox_l1_mat
-    prox    = prox_l1_mat_optimized( lambda_tfocs, nCols, zeroID ); % no sum(x)=b constraint.
+    %JMF 2 Dec 2018: optimized version is now the default in TFOCS; will use mex if it's compiled
+    prox    = prox_l1_mat(lambda_tfocs, nCols, zeroID); % no sum(x)=b constraint.
 end
 
 tfocs_opts.maxIts       = maxIter;


### PR DESCRIPTION
This just handles the optimized functons getting renamed in TFOCS.